### PR TITLE
[FEAT] - PS-12 - Salvamento de endereço de usuário e tratativa de erros com controller advice

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,8 +52,11 @@ dependencies {
 	// Logging
 	implementation("io.github.microutils:kotlin-logging:3.0.0")
 
-	//Validators
+	// Validators
 	implementation("br.com.colman.simplecpfvalidator:simple-cpf-validator:2.2.0")
+
+	// Feign
+	implementation("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4")
 }
 
 detekt {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -121,7 +121,7 @@ complexity:
     excludes: [ ]
     active: true
     functionThreshold: 6
-    constructorThreshold: 13
+    constructorThreshold: 17
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []

--- a/src/main/kotlin/br/com/sisvoli/SisvoliApplication.kt
+++ b/src/main/kotlin/br/com/sisvoli/SisvoliApplication.kt
@@ -2,8 +2,10 @@ package br.com.sisvoli
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
+@EnableFeignClients
 class SisvoliApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/br/com/sisvoli/api/controllers/AddressController.kt
+++ b/src/main/kotlin/br/com/sisvoli/api/controllers/AddressController.kt
@@ -1,0 +1,8 @@
+package br.com.sisvoli.api.controllers
+
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/address")
+class AddressController

--- a/src/main/kotlin/br/com/sisvoli/api/controllers/AddressController.kt
+++ b/src/main/kotlin/br/com/sisvoli/api/controllers/AddressController.kt
@@ -1,8 +1,24 @@
 package br.com.sisvoli.api.controllers
 
+import br.com.sisvoli.api.requests.AddressRequest
+import br.com.sisvoli.models.AddressModel
+import br.com.sisvoli.services.interfaces.AddressService
+import br.com.sisvoli.util.JWTUtil
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/address")
-class AddressController
+class AddressController(
+    val addressService: AddressService,
+    val jwtUtil: JWTUtil
+) {
+
+    @PostMapping
+    fun save(@RequestBody addressModel: AddressRequest): AddressModel {
+        val usernameRequest = jwtUtil.getUsername()
+        return addressService.save(addressModel, usernameRequest)
+    }
+}

--- a/src/main/kotlin/br/com/sisvoli/api/controllers/UserController.kt
+++ b/src/main/kotlin/br/com/sisvoli/api/controllers/UserController.kt
@@ -2,7 +2,7 @@ package br.com.sisvoli.api.controllers
 
 import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.api.responses.UserResponse
-import br.com.sisvoli.services.UserService
+import br.com.sisvoli.services.interfaces.UserService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping

--- a/src/main/kotlin/br/com/sisvoli/api/requests/AddressRequest.kt
+++ b/src/main/kotlin/br/com/sisvoli/api/requests/AddressRequest.kt
@@ -1,0 +1,23 @@
+package br.com.sisvoli.api.requests
+
+import br.com.sisvoli.models.AddressModel
+import java.util.UUID
+
+data class AddressRequest(
+    val zipCode: String,
+    val number: String,
+    val street: String,
+    val district: String,
+    val complement: String,
+    val cityId: Long
+) {
+    fun toAddressModel(userId: UUID) = AddressModel(
+        zipCode = zipCode,
+        number = number,
+        street = street,
+        district = district,
+        complement = complement,
+        cityId = cityId,
+        userId = userId
+    )
+}

--- a/src/main/kotlin/br/com/sisvoli/config/security/CustomAuthenticationFilter.kt
+++ b/src/main/kotlin/br/com/sisvoli/config/security/CustomAuthenticationFilter.kt
@@ -52,6 +52,7 @@ class CustomAuthenticationFilter(
         val tokens = mutableMapOf<String, String>()
         tokens.put("access_token", accessToken)
         tokens.put("refresh_token", refreshToken)
+        tokens.put("userName", user.username)
         response.contentType = APPLICATION_JSON_VALUE
         ObjectMapper().writeValue(response.outputStream, tokens)
     }

--- a/src/main/kotlin/br/com/sisvoli/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/br/com/sisvoli/config/security/SecurityConfig.kt
@@ -42,12 +42,14 @@ class SecurityConfig(
             .authorizeRequests()
             .antMatchers("/user/new")
             .permitAll()
+            .and()
+            .authorizeRequests()
+            .anyRequest()
+            .authenticated()
 
         // Verificação de role ao acessar endpoint
         // http.authorizeRequests().antMatchers("/ola/oi").hasAnyAuthority("ADMIN")
         // http.authorizeRequests().antMatchers("/ola").hasAnyAuthority("DEFAULT")
-
-        http.authorizeRequests().anyRequest().authenticated()
 
         http.addFilter(customAuthenticationFilter)
 

--- a/src/main/kotlin/br/com/sisvoli/database/entities/AddressEntity.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/entities/AddressEntity.kt
@@ -1,0 +1,73 @@
+package br.com.sisvoli.database.entities
+
+import br.com.sisvoli.models.AddressModel
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import javax.persistence.OneToOne
+import javax.persistence.Table
+
+@Entity
+@Table(name = "tb_address")
+class AddressEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.TABLE)
+    val id: UUID? = null,
+
+    @Column(name = "zip_code", nullable = false, length = 255)
+    val zipCode: String,
+
+    @Column(name = "number", nullable = false, length = 255)
+    val number: String,
+
+    @Column(name = "street", nullable = false, length = 255)
+    val street: String,
+
+    @Column(name = "district", nullable = false, length = 255)
+    val district: String,
+
+    @Column(name = "complement", nullable = false, length = 255)
+    val complement: String,
+
+    @ManyToOne
+    @JoinColumn(name = "city_id")
+    val cityEntity: CityEntity,
+
+    @OneToOne
+    @JoinColumn(name = "user_owner_id")
+    val userEntity: UserEntity
+) {
+
+    fun toAddressModel() = AddressModel(
+        id = id,
+        zipCode = zipCode,
+        number = number,
+        street = street,
+        district = district,
+        complement = complement,
+        cityId = cityEntity.id!!,
+        userId = userEntity.id!!
+    )
+
+    companion object {
+        fun of(
+            addressModel: AddressModel,
+            cityEntity: CityEntity,
+            userEntity: UserEntity
+        ) = AddressEntity(
+            id = addressModel.id,
+            zipCode = addressModel.zipCode,
+            number = addressModel.number,
+            street = addressModel.street,
+            district = addressModel.district,
+            complement = addressModel.complement,
+            cityEntity = cityEntity,
+            userEntity = userEntity
+        )
+    }
+}

--- a/src/main/kotlin/br/com/sisvoli/database/entities/AddressEntity.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/entities/AddressEntity.kt
@@ -1,11 +1,11 @@
 package br.com.sisvoli.database.entities
 
 import br.com.sisvoli.models.AddressModel
+import org.hibernate.annotations.GenericGenerator
 import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
-import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
@@ -16,7 +16,11 @@ import javax.persistence.Table
 @Table(name = "tb_address")
 class AddressEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.TABLE)
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(
+        name = "UUID",
+        strategy = "org.hibernate.id.UUIDGenerator"
+    )
     val id: UUID? = null,
 
     @Column(name = "zip_code", nullable = false, length = 255)

--- a/src/main/kotlin/br/com/sisvoli/database/entities/UserEntity.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/entities/UserEntity.kt
@@ -17,6 +17,7 @@ import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
+import javax.persistence.OneToOne
 import javax.persistence.Table
 import javax.validation.constraints.Email
 
@@ -67,7 +68,10 @@ class UserEntity(
 
     @ManyToOne
     @JoinColumn(name = "role_id", nullable = false)
-    val role: RoleEntity
+    val role: RoleEntity,
+
+    @OneToOne(mappedBy = "userEntity")
+    val addressEntity: AddressEntity? = null
 ) {
 
     fun toUserModel(): UserModel {

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/AddressRepositoryImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/AddressRepositoryImpl.kt
@@ -17,8 +17,10 @@ class AddressRepositoryImpl(
     val citySpringDataRepository: CitySpringDataRepository
 ) : AddressRepository {
     override fun save(addressModel: AddressModel): AddressModel {
-        val userEntity = userSpringDataRepository.findById(addressModel.userId).orElseThrow { UserNotFoundException() }
-        val cityEntity = citySpringDataRepository.findById(addressModel.cityId).orElseThrow { CityNotFoundException() }
+        val userEntity = userSpringDataRepository.findById(addressModel.userId)
+            .orElseThrow { UserNotFoundException() }
+        val cityEntity = citySpringDataRepository.findById(addressModel.cityId)
+            .orElseThrow { CityNotFoundException() }
 
         val addressEntity = AddressEntity.of(addressModel, cityEntity, userEntity)
 

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/AddressRepositoryImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/AddressRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package br.com.sisvoli.database.repositories.implementations
+
+import br.com.sisvoli.database.entities.AddressEntity
+import br.com.sisvoli.database.repositories.interfaces.AddressRepository
+import br.com.sisvoli.database.repositories.springData.AddressSpringDataRepository
+import br.com.sisvoli.database.repositories.springData.CitySpringDataRepository
+import br.com.sisvoli.database.repositories.springData.UserSpringDataRepository
+import br.com.sisvoli.exceptions.notFound.CityNotFoundException
+import br.com.sisvoli.exceptions.notFound.UserNotFoundException
+import br.com.sisvoli.models.AddressModel
+import org.springframework.stereotype.Component
+
+@Component
+class AddressRepositoryImpl(
+    val addressSpringDataRepository: AddressSpringDataRepository,
+    val userSpringDataRepository: UserSpringDataRepository,
+    val citySpringDataRepository: CitySpringDataRepository
+) : AddressRepository {
+    override fun save(addressModel: AddressModel): AddressModel {
+        val userEntity = userSpringDataRepository.findById(addressModel.userId).orElseThrow { UserNotFoundException() }
+        val cityEntity = citySpringDataRepository.findById(addressModel.cityId).orElseThrow { CityNotFoundException() }
+
+        val addressEntity = AddressEntity.of(addressModel, cityEntity, userEntity)
+
+        return addressSpringDataRepository.save(addressEntity).toAddressModel()
+    }
+}

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/UserRepositoryImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/UserRepositoryImpl.kt
@@ -1,7 +1,10 @@
-package br.com.sisvoli.database.repositories
+package br.com.sisvoli.database.repositories.implementations
 
 import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.database.entities.UserEntity
+import br.com.sisvoli.database.repositories.interfaces.UserRepository
+import br.com.sisvoli.database.repositories.springData.RoleSpringDataRepository
+import br.com.sisvoli.database.repositories.springData.UserSpringDataRepository
 import br.com.sisvoli.enums.RoleEnum
 import br.com.sisvoli.models.UserModel
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/UserRepositoryImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/implementations/UserRepositoryImpl.kt
@@ -6,6 +6,7 @@ import br.com.sisvoli.database.repositories.interfaces.UserRepository
 import br.com.sisvoli.database.repositories.springData.RoleSpringDataRepository
 import br.com.sisvoli.database.repositories.springData.UserSpringDataRepository
 import br.com.sisvoli.enums.RoleEnum
+import br.com.sisvoli.exceptions.notFound.UserNotFoundException
 import br.com.sisvoli.models.UserModel
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Component
@@ -23,6 +24,6 @@ class UserRepositoryImpl(
     }
 
     override fun findByUsername(username: String): UserModel {
-        return userSpringDataRepository.findByUsername(username).toUserModel()
+        return userSpringDataRepository.findByUsername(username)?.toUserModel() ?: throw UserNotFoundException()
     }
 }

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/interfaces/AddressRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/interfaces/AddressRepository.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.database.repositories.interfaces
+
+import br.com.sisvoli.models.AddressModel
+
+interface AddressRepository {
+    fun save(addressModel: AddressModel): AddressModel
+}

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/interfaces/UserRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/interfaces/UserRepository.kt
@@ -1,4 +1,4 @@
-package br.com.sisvoli.database.repositories
+package br.com.sisvoli.database.repositories.interfaces
 
 import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.models.UserModel

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/springData/AddressSpringDataRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/springData/AddressSpringDataRepository.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.database.repositories.springData
+
+import br.com.sisvoli.database.entities.AddressEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface AddressSpringDataRepository : JpaRepository<AddressEntity, UUID>

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/springData/CitySpringDataRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/springData/CitySpringDataRepository.kt
@@ -1,0 +1,6 @@
+package br.com.sisvoli.database.repositories.springData
+
+import br.com.sisvoli.database.entities.CityEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CitySpringDataRepository : JpaRepository<CityEntity, Long>

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/springData/RoleSpringDataRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/springData/RoleSpringDataRepository.kt
@@ -1,4 +1,4 @@
-package br.com.sisvoli.database.repositories
+package br.com.sisvoli.database.repositories.springData
 
 import br.com.sisvoli.database.entities.RoleEntity
 import org.springframework.data.jpa.repository.JpaRepository

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/springData/StateSpringDataRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/springData/StateSpringDataRepository.kt
@@ -1,4 +1,4 @@
-package br.com.sisvoli.database.repositories
+package br.com.sisvoli.database.repositories.springData
 
 import br.com.sisvoli.database.entities.StateEntity
 import org.springframework.data.jpa.repository.JpaRepository

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/springData/UserSpringDataRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/springData/UserSpringDataRepository.kt
@@ -1,4 +1,4 @@
-package br.com.sisvoli.database.repositories
+package br.com.sisvoli.database.repositories.springData
 
 import br.com.sisvoli.database.entities.UserEntity
 import org.springframework.data.jpa.repository.JpaRepository

--- a/src/main/kotlin/br/com/sisvoli/database/repositories/springData/UserSpringDataRepository.kt
+++ b/src/main/kotlin/br/com/sisvoli/database/repositories/springData/UserSpringDataRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface UserSpringDataRepository : JpaRepository<UserEntity, UUID> {
-    fun findByUsername(username: String): UserEntity
+    fun findByUsername(username: String): UserEntity?
 }

--- a/src/main/kotlin/br/com/sisvoli/exceptions/ControllerAdvice.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/ControllerAdvice.kt
@@ -1,6 +1,7 @@
 package br.com.sisvoli.exceptions
 
 import br.com.sisvoli.api.responses.ErrorResponse
+import br.com.sisvoli.exceptions.invalid.InvalidCPFException
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.HttpRequestMethodNotSupportedException
@@ -24,5 +25,10 @@ class ControllerAdvice {
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun messageNotReadable(ex: Exception, request: WebRequest): ResponseEntity<ErrorResponse> {
         return ErrorResponse.of(ErrorMessages.PS_0013).responseEntity()
+    }
+
+    @ExceptionHandler(InvalidCPFException::class)
+    fun invalidCPFException(ex: Exception, request: WebRequest): ResponseEntity<ErrorResponse> {
+        return ErrorResponse.of(ErrorMessages.PS_0015).responseEntity()
     }
 }

--- a/src/main/kotlin/br/com/sisvoli/exceptions/ControllerAdvice.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/ControllerAdvice.kt
@@ -2,6 +2,8 @@ package br.com.sisvoli.exceptions
 
 import br.com.sisvoli.api.responses.ErrorResponse
 import br.com.sisvoli.exceptions.invalid.InvalidCPFException
+import br.com.sisvoli.exceptions.notFound.CityNotFoundException
+import br.com.sisvoli.exceptions.notFound.UserNotFoundException
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.HttpRequestMethodNotSupportedException
@@ -30,5 +32,15 @@ class ControllerAdvice {
     @ExceptionHandler(InvalidCPFException::class)
     fun invalidCPFException(ex: Exception, request: WebRequest): ResponseEntity<ErrorResponse> {
         return ErrorResponse.of(ErrorMessages.PS_0015).responseEntity()
+    }
+
+    @ExceptionHandler(UserNotFoundException::class)
+    fun userNotFoundException(ex: Exception, request: WebRequest): ResponseEntity<ErrorResponse> {
+        return ErrorResponse.of(ErrorMessages.PS_0004).responseEntity()
+    }
+
+    @ExceptionHandler(CityNotFoundException::class)
+    fun cityNotFoundException(ex: Exception, request: WebRequest): ResponseEntity<ErrorResponse> {
+        return ErrorResponse.of(ErrorMessages.PS_0005).responseEntity()
     }
 }

--- a/src/main/kotlin/br/com/sisvoli/exceptions/ErrorMessages.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/ErrorMessages.kt
@@ -72,5 +72,10 @@ enum class ErrorMessages(val httpCode: Int, val code: String, val message: Strin
         HttpStatus.CONFLICT.value(),
         "PS-0014",
         "Voto já computado para a enquete em questão"
+    ),
+    PS_0015(
+        HttpStatus.BAD_REQUEST.value(),
+        "PS-0015",
+        "CPF inválido"
     )
 }

--- a/src/main/kotlin/br/com/sisvoli/exceptions/SisvoliBaseRuntimeException.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/SisvoliBaseRuntimeException.kt
@@ -1,0 +1,5 @@
+package br.com.sisvoli.exceptions
+
+abstract class SisvoliBaseRuntimeException(
+    override val message: String
+) : RuntimeException(message)

--- a/src/main/kotlin/br/com/sisvoli/exceptions/auth/InvalidAuthenticationUsername.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/auth/InvalidAuthenticationUsername.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.exceptions.auth
+
+import br.com.sisvoli.exceptions.SisvoliBaseRuntimeException
+
+class InvalidAuthenticationUsername(
+    override val message: String = "Nome de usuário inválido na autenticação"
+) : SisvoliBaseRuntimeException(message)

--- a/src/main/kotlin/br/com/sisvoli/exceptions/invalid/InvalidCPFException.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/invalid/InvalidCPFException.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.exceptions.invalid
+
+import br.com.sisvoli.exceptions.SisvoliBaseRuntimeException
+
+class InvalidCPFException(
+    override val message: String = "CPF inválido"
+) : SisvoliBaseRuntimeException(message)

--- a/src/main/kotlin/br/com/sisvoli/exceptions/invalid/InvalidUUIDException.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/invalid/InvalidUUIDException.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.exceptions.invalid
+
+import br.com.sisvoli.exceptions.SisvoliBaseRuntimeException
+
+class InvalidUUIDException(
+    override val message: String = "UUID inválido"
+) : SisvoliBaseRuntimeException(message)

--- a/src/main/kotlin/br/com/sisvoli/exceptions/notFound/CityNotFoundException.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/notFound/CityNotFoundException.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.exceptions.notFound
+
+import br.com.sisvoli.exceptions.SisvoliBaseRuntimeException
+
+class CityNotFoundException(
+    override val message: String = "City not found"
+) : SisvoliBaseRuntimeException(message)

--- a/src/main/kotlin/br/com/sisvoli/exceptions/notFound/UserNotFoundException.kt
+++ b/src/main/kotlin/br/com/sisvoli/exceptions/notFound/UserNotFoundException.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.exceptions.notFound
+
+import br.com.sisvoli.exceptions.SisvoliBaseRuntimeException
+
+class UserNotFoundException(
+    override val message: String = "User not found"
+) : SisvoliBaseRuntimeException(message)

--- a/src/main/kotlin/br/com/sisvoli/models/AddressModel.kt
+++ b/src/main/kotlin/br/com/sisvoli/models/AddressModel.kt
@@ -1,0 +1,14 @@
+package br.com.sisvoli.models
+
+import java.util.UUID
+
+data class AddressModel(
+    val id: UUID? = null,
+    val zipCode: String,
+    val number: String,
+    val street: String,
+    val district: String,
+    val complement: String,
+    val cityId: Long,
+    val userId: UUID
+)

--- a/src/main/kotlin/br/com/sisvoli/services/implementations/AddressServiceImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/implementations/AddressServiceImpl.kt
@@ -1,0 +1,13 @@
+package br.com.sisvoli.services.implementations
+
+import br.com.sisvoli.database.repositories.interfaces.AddressRepository
+import br.com.sisvoli.models.AddressModel
+import br.com.sisvoli.services.interfaces.AddressService
+
+class AddressServiceImpl(
+    private val addressRepository: AddressRepository
+) : AddressService {
+    override fun save(addressModel: AddressModel): AddressModel {
+        return addressRepository.save(addressModel)
+    }
+}

--- a/src/main/kotlin/br/com/sisvoli/services/implementations/AddressServiceImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/implementations/AddressServiceImpl.kt
@@ -1,13 +1,19 @@
 package br.com.sisvoli.services.implementations
 
+import br.com.sisvoli.api.requests.AddressRequest
 import br.com.sisvoli.database.repositories.interfaces.AddressRepository
 import br.com.sisvoli.models.AddressModel
 import br.com.sisvoli.services.interfaces.AddressService
+import br.com.sisvoli.services.interfaces.UserService
+import org.springframework.stereotype.Service
 
+@Service
 class AddressServiceImpl(
-    private val addressRepository: AddressRepository
+    private val addressRepository: AddressRepository,
+    private val userService: UserService
 ) : AddressService {
-    override fun save(addressModel: AddressModel): AddressModel {
-        return addressRepository.save(addressModel)
+    override fun save(addressRequest: AddressRequest, username: String): AddressModel {
+        val userModel = userService.findByUsername(username)
+        return addressRepository.save(addressRequest.toAddressModel(userModel.id!!))
     }
 }

--- a/src/main/kotlin/br/com/sisvoli/services/implementations/UserServiceImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/implementations/UserServiceImpl.kt
@@ -5,6 +5,7 @@ import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.api.responses.UserResponse
 import br.com.sisvoli.database.repositories.interfaces.UserRepository
 import br.com.sisvoli.exceptions.invalid.InvalidCPFException
+import br.com.sisvoli.models.UserModel
 import br.com.sisvoli.services.interfaces.UserService
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
@@ -23,6 +24,10 @@ class UserServiceImpl(
         } else {
             throw InvalidCPFException()
         }
+    }
+
+    override fun findByUsername(username: String): UserModel {
+        return userRepository.findByUsername(username)
     }
 
     override fun loadUserByUsername(username: String): UserDetails {

--- a/src/main/kotlin/br/com/sisvoli/services/implementations/UserServiceImpl.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/implementations/UserServiceImpl.kt
@@ -1,9 +1,11 @@
-package br.com.sisvoli.services
+package br.com.sisvoli.services.implementations
 
 import br.com.colman.simplecpfvalidator.isCpf
 import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.api.responses.UserResponse
-import br.com.sisvoli.database.repositories.UserRepository
+import br.com.sisvoli.database.repositories.interfaces.UserRepository
+import br.com.sisvoli.exceptions.invalid.InvalidCPFException
+import br.com.sisvoli.services.interfaces.UserService
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
@@ -19,7 +21,7 @@ class UserServiceImpl(
         return if (isCpf(userModel.cpf)) {
             userRepository.save(userModel).toUserResponse()
         } else {
-            throw Exception("CPF invalido")
+            throw InvalidCPFException()
         }
     }
 

--- a/src/main/kotlin/br/com/sisvoli/services/interfaces/AddressService.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/interfaces/AddressService.kt
@@ -1,7 +1,8 @@
 package br.com.sisvoli.services.interfaces
 
+import br.com.sisvoli.api.requests.AddressRequest
 import br.com.sisvoli.models.AddressModel
 
 interface AddressService {
-    fun save(addressModel: AddressModel): AddressModel
+    fun save(addressRequest: AddressRequest, username: String): AddressModel
 }

--- a/src/main/kotlin/br/com/sisvoli/services/interfaces/AddressService.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/interfaces/AddressService.kt
@@ -1,0 +1,7 @@
+package br.com.sisvoli.services.interfaces
+
+import br.com.sisvoli.models.AddressModel
+
+interface AddressService {
+    fun save(addressModel: AddressModel): AddressModel
+}

--- a/src/main/kotlin/br/com/sisvoli/services/interfaces/UserService.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/interfaces/UserService.kt
@@ -2,7 +2,9 @@ package br.com.sisvoli.services.interfaces
 
 import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.api.responses.UserResponse
+import br.com.sisvoli.models.UserModel
 
 interface UserService {
     fun save(userModel: UserRequest): UserResponse
+    fun findByUsername(username: String): UserModel
 }

--- a/src/main/kotlin/br/com/sisvoli/services/interfaces/UserService.kt
+++ b/src/main/kotlin/br/com/sisvoli/services/interfaces/UserService.kt
@@ -1,4 +1,4 @@
-package br.com.sisvoli.services
+package br.com.sisvoli.services.interfaces
 
 import br.com.sisvoli.api.requests.UserRequest
 import br.com.sisvoli.api.responses.UserResponse

--- a/src/main/kotlin/br/com/sisvoli/util/Converters.kt
+++ b/src/main/kotlin/br/com/sisvoli/util/Converters.kt
@@ -1,0 +1,12 @@
+package br.com.sisvoli.util
+
+import br.com.sisvoli.exceptions.invalid.InvalidUUIDException
+import java.util.UUID
+
+fun stringToUUID(value: String): UUID {
+    return runCatching {
+        UUID.fromString(value)
+    }.onFailure {
+        throw InvalidUUIDException()
+    }.getOrThrow()
+}

--- a/src/main/kotlin/br/com/sisvoli/util/JWTUtil.kt
+++ b/src/main/kotlin/br/com/sisvoli/util/JWTUtil.kt
@@ -1,0 +1,12 @@
+package br.com.sisvoli.util
+
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Service
+
+@Service
+class JWTUtil {
+
+    fun getUsername(): String {
+        return SecurityContextHolder.getContext().authentication.principal as String
+    }
+}


### PR DESCRIPTION
- Usuário pode salvar um endereço desde que esteja logado no sistema
- O endereço será atribuído automaticamente ao usuário, sem que ele envie algum ID manualmente
- A identificação do usuário logado é feita pelo token JWT da requisição